### PR TITLE
use `become` instead of `sudo`

### DIFF
--- a/tasks/section1.yml
+++ b/tasks/section1.yml
@@ -1,5 +1,5 @@
 - name: "1.8 | Ensure updates, patches, and additional security software are installed"
-  sudo: yes
+  become: yes
   apt:
       update_cache: yes
       upgrade: dist


### PR DESCRIPTION
Got the following error from Ansible 2.4.1.0:

```
[WARNING]: Ignoring invalid attribute: sudo
```

followed by the task failing with a permissions error.

https://docs.ansible.com/ansible/latest/become.html#directives