### PR TITLE
[WORK IN PROGRESS] add an easy way to test the role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
+# Ansible
 *.retry
+
+# Packer
+*.pem

--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ There are many role variables defined in defaults/main.yml.
 
 By default, many of the variables are turned off. Please review and adjust to meet your organizational requirements.
 
-Note, a subset of controls were removed due to operational impact or organizational dependent variables. Those are listed [here](https://docs.google.com/spreadsheets/d/1hHbPDnm5WspzGt6F67_Dw2GgLA1E0-NCAsIGeHJLK7s/edit#gid=0) *Note: Must have a GSA account to access.
-
+Note, a subset of controls were removed due to operational impact or organizational dependent variables. Those are listed [here](https://docs.google.com/spreadsheets/d/1hHbPDnm5WspzGt6F67_Dw2GgLA1E0-NCAsIGeHJLK7s/edit#gid=0) *Note: Must have a GSA account to access.*
 
 Dependencies
 ------------
@@ -31,7 +30,7 @@ Ansible > 2.4
 Example Playbook
 -------------------------
 
-```
+```yaml
 ---
 - name: Harden Server
   hosts: all
@@ -40,11 +39,19 @@ Example Playbook
   roles:
     - gsa_hardening
 ```
-How to test locally
---------------------------
-```
-ansible-playbook playbook.yml --connection=local
-```
+
+## Testing
+
+To test the role against a bare AWS AMI:
+
+1. Install [Packer](https://www.packer.io/).
+1. [Specify your AWS credentials as environment variables.](https://www.packer.io/docs/builders/amazon.html#automatic-lookup)
+1. Build an AMI using the role.
+
+    ```sh
+    cd test
+    packer build packer.json
+    ```
 
 License
 -------

--- a/tasks/section1.yml
+++ b/tasks/section1.yml
@@ -1,5 +1,5 @@
 - name: "1.8 | Ensure updates, patches, and additional security software are installed"
-  sudo: yes
+  become: yes
   apt:
       update_cache: yes
       upgrade: dist

--- a/test/ansible.cfg
+++ b/test/ansible.cfg
@@ -1,0 +1,5 @@
+[defaults]
+# without this, the connection to a new instance is interactive
+host_key_checking = False
+
+roles_path = roles/:../../

--- a/test/main.yml
+++ b/test/main.yml
@@ -1,0 +1,11 @@
+---
+# based on https://gist.github.com/gwillem/4ba393dceb55e5ae276a87300f6b8e6f
+- hosts: all
+  gather_facts: false
+  tasks:
+  - name: Install Python 2
+    raw: test -e /usr/bin/python || (sudo apt-get -y update && sudo apt-get install -y python-minimal)
+
+- hosts: all
+  roles:
+    - ansible-os-ubuntu-16

--- a/test/packer.json
+++ b/test/packer.json
@@ -1,0 +1,28 @@
+{
+  "variables": {
+    "region": "{{env `AWS_DEFAULT_REGION`}}"
+  },
+  "builders": [{
+    "type": "amazon-ebs",
+    "region": "{{user `region`}}",
+    "source_ami_filter": {
+      "filters": {
+        "virtualization-type": "hvm",
+        "name": "*ubuntu-xenial-16.04-amd64-server-*",
+        "root-device-type": "ebs"
+      },
+      "owners": ["099720109477"],
+      "most_recent": true
+    },
+    "instance_type": "t2.micro",
+    "ssh_username": "ubuntu",
+    "ami_name": "ansible-os-ubuntu-16",
+    "force_deregister": true
+  }],
+  "provisioners": [
+    {
+      "type": "ansible",
+      "playbook_file": "main.yml"
+    }
+  ]
+}


### PR DESCRIPTION
Builds on #1.

I was running into issues when trying to use the role in the context of another repository - this gives a way to run the role against a new EC2 instance, for testing in isolation.