### PR TITLE
Adding changes required for CIS 1.1.  

### DIFF
--- a/tasks/section4.yml
+++ b/tasks/section4.yml
@@ -36,6 +36,14 @@
   tags:
       - id_4.1.3
 
+- name: "4.1.12 | Collect Use of Privileged Commands"
+  shell: find /* -xdev \( -perm -4000 -o -perm -2000 \) -type f 2>/dev/null | awk '{print "-a always,exit -F path=" $1 " -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged" }'
+  register: audit_lines_for_find
+  changed_when: False
+  when: ubu16gsa_auditd_config == true
+  tags:
+    - id_4.1.12
+
 - name: "4.1.4-4.1.18 | Configure Auditd rules and configurations."
   template:
     src: audit_rules
@@ -57,12 +65,7 @@
       - id_4.1.17
       - id_4.1.18
 
-- name: "4.1.12 | Collect Use of Privileged Commands"
-  shell: find / -xdev \( -perm -4000 -o -perm -2000 \) -type f | awk '{print "-a always,exit -F path=" $1 " -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged" }'
-  register: audit_lines_for_find
-  changed_when: False
-  tags:
-    - id_4.1.12
+
 
 - name: "4.2.1.1 Ensure rsyslog Service is enabled"
   systemd:

--- a/tasks/section5.yml
+++ b/tasks/section5.yml
@@ -213,7 +213,7 @@
       state: present
       dest: /etc/ssh/sshd_config
       regexp: '^ClientAliveInterval'
-      line: 'ClientAliveInterval 900'
+      line: 'ClientAliveInterval 300'
   tags:
       - id_5.2.13
 
@@ -257,6 +257,10 @@
       line: '{{ item.key }} = {{ item.value }}'
   with_items:
       - { key: 'minlen',  value: '16' }
+      - { key: 'dcredit',  value: '-1' }
+      - { key: 'ucredit',  value: '-1' }
+      - { key: 'ocredit',  value: '-1' }
+      - { key: 'lcredit',  value: '-1' }
       - { key: 'retry',  value: '3' }
   tags:
       - id_5.3.1
@@ -288,12 +292,12 @@
   tags:
       - id_5.4.1.1
 
-- name: "5.4.1.2 | Ensure minimum days between password changes is 0 or more"
+- name: "5.4.1.2 | Ensure minimum days between password changes is 7 or more"
   lineinfile:
       state: present
       dest: /etc/login.defs
       regexp: '^PASS_MIN_DAYS'
-      line: 'PASS_MIN_DAYS 0'
+      line: 'PASS_MIN_DAYS 7'
   tags:
       - id_5.4.1.2
 

--- a/tasks/section6.yml
+++ b/tasks/section6.yml
@@ -11,7 +11,7 @@
   file:
       dest: /etc/shadow
       owner: root
-      group: root
+      group: shadow
       mode: 0000
   tags:
       - rule_6.1.3
@@ -29,7 +29,7 @@
   file:
       dest: /etc/gshadow
       owner: root
-      group: root
+      group: shadow
       mode: 0000
   tags:
       - rule_6.1.5

--- a/templates/audit_rules
+++ b/templates/audit_rules
@@ -62,6 +62,13 @@
 -a always,exit -F arch=b64 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
 -a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
 
+# 4.1.12 Ensure use of privileged commands is collected
+{% if audit_lines_for_find is defined %}
+{% for audit_command in audit_lines_for_find.stdout_lines %}
+{{ audit_command }}
+{% endfor %}
+{% endif %}
+
 # 4.1.13 Collect Successful File System Mounts
 -a always,exit -F arch=b64 -S mount -F auid>=1000 -F auid!=4294967295 -k mounts
 -a always,exit -F arch=b32 -S mount -F auid>=1000 -F auid!=4294967295 -k mounts

--- a/templates/common-password
+++ b/templates/common-password
@@ -26,6 +26,8 @@ password        requisite                       pam_pwquality.so try_first_pass 
 password        [success=1 default=ignore]      pam_unix.so obscure use_authtok try_first_pass sha512
 # here's the fallback if no module succeeds
 password        requisite                       pam_deny.so
+#CIS 5.3.3 Ensure password reuse is limited
+password        required                        pam_pwhistory.so remember=5
 # prime the stack with a positive return value if there isn't one already;
 # this avoids us returning an error just because nothing sets a success code
 # since the modules above will each just jump around


### PR DESCRIPTION
Sections modified: 4.1.12, 5.2.12, 5.3.1, 5.3.3, 5.4.1.2, 6.1.3, 6.1.5
Changes made:

4.1.12 | Extended the find command for privileged executables to include everything under /* and pipe any errors to /dev/null.  I included the registered stdout lines in the audit_rules remplate.

5.2.12 | Set ClientAliveInterval to 300 vs 900 per requirements

5.3.1 | Added additional *credit values set to -1 in the pwquality.conf

5.3.3 |  Updated the common-password template to include the password history settings

5.4.1.2 | Ensure minimum days between password changes is 7 vs 0

6.1.3 | Changed group to shadow as required

6.1.5 | Changed group to shadow as required

CI Tests passed, so SHOULD be a smooth merge.