### PR TITLE
Modifying CIS-5.3.3 from 5 to 24 per GSA BigFix requirement.

### DIFF
--- a/templates/common-password
+++ b/templates/common-password
@@ -27,7 +27,7 @@ password        [success=1 default=ignore]      pam_unix.so obscure use_authtok 
 # here's the fallback if no module succeeds
 password        requisite                       pam_deny.so
 #CIS 5.3.3 Ensure password reuse is limited
-password        required                        pam_pwhistory.so remember=5
+password        required                        pam_pwhistory.so remember=24
 # prime the stack with a positive return value if there isn't one already;
 # this avoids us returning an error just because nothing sets a success code
 # since the modules above will each just jump around


### PR DESCRIPTION
GSA requires 24 past passwords to be "remembered" vs the CIS default of 5.