### PR TITLE
Modifying CIS-5.3.1 to set the character type requirements to 0 

### DIFF
--- a/tasks/section5.yml
+++ b/tasks/section5.yml
@@ -257,10 +257,10 @@
       line: '{{ item.key }} = {{ item.value }}'
   with_items:
       - { key: 'minlen',  value: '16' }
-      - { key: 'dcredit',  value: '-1' }
-      - { key: 'ucredit',  value: '-1' }
-      - { key: 'ocredit',  value: '-1' }
-      - { key: 'lcredit',  value: '-1' }
+      - { key: 'dcredit',  value: '0' }
+      - { key: 'ucredit',  value: '0' }
+      - { key: 'ocredit',  value: '0' }
+      - { key: 'lcredit',  value: '0' }
       - { key: 'retry',  value: '3' }
   tags:
       - id_5.3.1


### PR DESCRIPTION
This change supports the GSA requirement to allow any characters.
This came up during recent audit reports.