### PR TITLE
Bug: GRUB_CMDLINE_LINUX conflicts

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+
+# Use update-grub to regenerate grub.cfg
+- name: update-grub
+  command: update-grub
+  failed_when: ('error' in grub_register_update.stderr)
+  register: grub_register_update

--- a/tasks/section1.yml
+++ b/tasks/section1.yml
@@ -193,10 +193,14 @@
 
 - name: "1.6.2.1 | Ensure AppArmor is not disabled in bootloader configuration"
   lineinfile:
-      dest: /etc/default/grub
-      regexp: 'GRUB_CMDLINE_LINUX=(""|apparmor="1 security=apparmor")'
-      line: 'GRUB_CMDLINE_LINUX=apparmor="1 security=apparmor"'
-      state: present
+    dest: /etc/default/grub
+    regexp: '^GRUB_CMDLINE_LINUX="(?!.* {{ item.regex }})(.*)"'
+    line: 'GRUB_CMDLINE_LINUX="\1 {{ item.context }}"'
+    state: present
+    backrefs: yes
+  with_items:
+    - { regex: 'apparmor=1 security=apparmor', context: 'apparmor=1 security=apparmor' }
+  notify: [ 'update-grub' ]
   when: ubu16gsa_config_apparmor == true
   tags:
     - id_1.6.2.1

--- a/tasks/section3.yml
+++ b/tasks/section3.yml
@@ -149,11 +149,15 @@
       - no_test
 
 - name: "3.3.3 | Ensure IPv6 is disabled"
-  lineinfile: >
-      dest=/etc/default/grub
-      line='GRUB_CMDLINE_LINUX="ipv6.disable=1"'
-      state=present
-      create=yes
+  lineinfile:
+    dest: /etc/default/grub
+    regexp: '^GRUB_CMDLINE_LINUX="(?!.* {{ item.regex }})(.*)"'
+    line: 'GRUB_CMDLINE_LINUX="\1 {{ item.context }}"'
+    state: present
+    backrefs: yes
+  with_items:
+    - { regex: 'ipv6.disable=', context: 'ipv6.disable=1' }
+  notify: [ 'update-grub' ]
   when: ubu16gsa_ipv6_disable == true
   tags:
       - id_3.3.3

--- a/tasks/section4.yml
+++ b/tasks/section4.yml
@@ -27,11 +27,15 @@
       - no_test
 
 - name: "4.1.3 | Ensure auditing for processes that start prior to auditd is enabled"
-  lineinfile: >
-      dest=/etc/default/grub
-      line='GRUB_CMDLINE_LINUX="audit=1"'
-      state=present
-      create=yes
+  lineinfile:
+    dest: /etc/default/grub
+    regexp: '^GRUB_CMDLINE_LINUX="(?!.* {{ item.regex }})(.*)"'
+    line: 'GRUB_CMDLINE_LINUX="\1 {{ item.context }}"'
+    state: present
+    backrefs: yes
+  with_items:
+    - { regex: 'audit=', context: 'audit=1' }
+  notify: [ 'update-grub' ]
   when: ubu16gsa_auditd_config == true
   tags:
       - id_4.1.3


### PR DESCRIPTION
Updates lineinfile regexes to append lines to GRUB_CMDLINE_LINUX instead of replace and adds update-grub handler to regenerate grub.cfg

Resolves #21 